### PR TITLE
Make interval for EventSource be in correct unit

### DIFF
--- a/src/server/event_source.rs
+++ b/src/server/event_source.rs
@@ -82,7 +82,7 @@ where
     }
     let mut ping = if params.ping > 0 {
         #[cfg(not(test))]
-        let interval = std::cmp::max(params.ping, 30);
+        let interval = std::cmp::max(params.ping, 30) * 1000;
         #[cfg(test)]
         let interval = params.ping * 1000;
 


### PR DESCRIPTION
Converts the unit for the interval from seconds into milliseconds when `test` isn't set