### PR TITLE
A more comprehensive threading test

### DIFF
--- a/src/tests/jmap_mail/email_thread.rs
+++ b/src/tests/jmap_mail/email_thread.rs
@@ -102,7 +102,6 @@ message here!".into(),
 References: <t2-msg1>
 From: test2@example.com
 To: test1@example.com
-In-Reply-To: <t1-msg1>
 Subject: my thread
 
 reply here!".into(),
@@ -116,7 +115,6 @@ reply here!".into(),
 References: <t2-msg1>
 From: test1@example.com
 To: test2@example.com
-In-Reply-To: <t1-msg1>
 Subject: my thread
 
 reply here!".into(),


### PR DESCRIPTION
I noticed some odd threading behavior and reported it in https://github.com/stalwartlabs/jmap-server/issues/34. This PR exposes the same issue in a test case as a first step towards fixing it.

You can run the test with `cargo test jmap_mail_tests -- --ignored`.

UPDATE: actually this didn't seem to reproduce #34. The test is still more thorough than before, but not as pertinent as intended.